### PR TITLE
Fixed wiki xml format for redmine client.

### DIFF
--- a/src/main/java/com/payneteasy/firewall/redmine/RedmineEasyClient.java
+++ b/src/main/java/com/payneteasy/firewall/redmine/RedmineEasyClient.java
@@ -43,7 +43,7 @@ public class RedmineEasyClient implements IRedmineClient {
         Preconditions.checkNotNull(pageName, "page name");
         return pageName.replaceAll("\\.", "_") + ".xml";
     }
-
+    
     private final HttpRequestFactory requestFactory;
     private final String url;
 
@@ -100,7 +100,6 @@ public class RedmineEasyClient implements IRedmineClient {
         WikiPageXml wikiPageXml = new WikiPageXml();
         wikiPageXml.setComments(comment);
         wikiPageXml.setText(text);
-        wikiPageXml.setTitle(title);
         wikiPageXml.setVersion(version);
 
         XmlNamespaceDictionary xmlNamespaceDictionary = new XmlNamespaceDictionary();


### PR DESCRIPTION
Sending different page name and title is harmfull,
because redmine uses page name to search for existing wiki pages
and saves title but not page name to DB.

This results in 422 error when trying to update existing page:

0. firewall-config tryes to create a page
1. Redmine searches for wiki page by page name
2. Page is not found
3. Redmine saves new page using page title only
4. Everything is OK, redmine responds 200 OK
5. firewall-config tryes to update the same page
6. Redmine searches for wiki page by page name
7. Page is not found
8. Redmine saves new page using page title only
9. It appears that page with that title already exists
10. Saving fails, redmine responds 422 Unprocessable Entity