### PR TITLE
build: upgrade the maven wrapper to 3.9.16

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -10,7 +10,7 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 | | |
 |---|---|
 | **Java 8** | The project compiles with `source`/`target` `1.8`. It runs on newer JREs, but do not raise the compiler level without checking — see [Limitations](/firewall-config/internals/limitations/). |
-| **Maven** | Not needed separately; use the bundled `./mvnw` wrapper (Maven 3.5.2). |
+| **Maven** | Not needed separately; use the bundled `./mvnw` wrapper (Maven 3.9.16). |
 | **`nwdiag`** | Only to render the [L3 diagram](/firewall-config/generators/l3-diagram/) to PNG/SVG. The generator itself only writes `network.diag`. Install with `apt install python3-nwdiag` (the binary is then `nwdiag3`). |
 | **A desktop session** | Only for the interactive [L2 editor](/firewall-config/generators/l2-diagram/). The SVG and PNG variants run headless. |
 


### PR DESCRIPTION
`.mvn/wrapper/maven-wrapper.properties` pinned **Maven 3.5.2 (October 2017)**. That is the single
reason two Dependabot PRs fail:

- #15 (`snakeyaml` 2.6 + `maven-assembly-plugin` 3.8.0 + `jacoco` 0.8.15) — all 210 tests pass, then
  `maven-assembly-plugin:3.8.0 requires Maven version 3.6.3`
- #17 (`maven-surefire-plugin` 3.5.6) — `maven-surefire-plugin:3.5.6 requires Maven version 3.6.3`

Neither failure has anything to do with the dependency being bumped. With the wrapper current, both
can be rebased and merged.

3.9.16 is the ceiling on purpose: Maven 4 requires Java 17, and this project compiles and ships on
Java 8. Only `distributionUrl` changes — `maven-wrapper.jar`, `mvnw` and `mvnw.cmd` are untouched, and
no `distributionSha256Sum` is configured.

## The risk here is the super-POM, not Maven

Three plugins in this build have no explicit `<version>`, so their versions come from whichever
Maven's super-POM supplies. Moving 3.5.2 → 3.9.16 changes all three:

| Plugin | 3.5.2 default | 3.9.16 default |
|---|---|---|
| `maven-compiler-plugin` | 3.1 | 3.13.0 |
| `maven-jar-plugin` | 2.4 | 3.4.1 |
| `maven-resources-plugin` | 2.6 | 3.3.1 |

New resources and jar plugins can change resource filtering and encoding, and this project's product
*is* its generated text — so `clean verify` passing is not sufficient evidence on its own.

## Verification

Run on JDK 8 (Zulu 1.8.0_322), the same major CI uses:

- `./mvnw -v` → `Apache Maven 3.9.16`, `Java version: 1.8.0_322`
- `./mvnw clean verify` → 210 tests, coverage gate met, same 83 classes in the JaCoCo bundle
- **All 7 golden iptables files regenerate byte-for-byte identical** from the fat jar — the check that
  actually covers the plugin-default change above
- The full demo-network sweep: every generator accepts the demo network

## Known leftover

`maven-compiler-plugin` still has no `<version>`, so Dependabot cannot manage it and Maven 3.9 warns
about the missing version. Deliberately left for a separate change rather than smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
