### PR TITLE
test: move to the unified org.hamcrest:hamcrest artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,24 @@
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- junit pulls hamcrest-core 1.3, whose org.hamcrest.* classes are the
+                     same names hamcrest 3.0 below already provides. Two copies on the
+                     test classpath resolve by jar order, not by version. -->
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
-        <!-- junit only brings hamcrest-core; hasSize/hasItem/hasEntry live here -->
+        <!-- hamcrest, not hamcrest-library: since 2.x the -library and -core artifacts
+             are empty stubs and everything (Matchers, MatcherAssert, hasSize/hasItem/
+             hasEntry) lives in this one jar. -->
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Supersedes #16, which Dependabot could not get right on its own.

Dependabot proposed `org.hamcrest:hamcrest-library` 1.3 → 3.0, and it fails to compile:

```
cannot find symbol
  symbol:   class Matchers
  location: package org.hamcrest
```

Since hamcrest 2.x, `hamcrest-library` and `hamcrest-core` are empty stub artifacts — `Matchers`,
`MatcherAssert` and the `hasSize`/`hasItem`/`hasEntry` matchers all moved into a single
`org.hamcrest:hamcrest` jar. Bumping the stub's version can only ever break the build.

## The change

- `org.hamcrest:hamcrest-library:1.3` → `org.hamcrest:hamcrest:3.0`
- exclude `hamcrest-core` from junit. This part matters: junit 4.13.2 pulls `hamcrest-core` 1.3, whose
  `org.hamcrest.*` classes have the *same names* hamcrest 3.0 provides. Two copies on the test
  classpath resolve by jar order rather than by version, which is the kind of thing that works locally
  and fails somewhere else.

**No test file changes.** All 20 test classes keep importing `org.hamcrest.Matchers.*` and
`org.hamcrest.MatcherAssert.assertThat` — same package, same class names in 3.0. The CLAUDE.md rule to
use `MatcherAssert.assertThat` rather than the deprecated `Assert.assertThat` is unaffected.

To be clear about the motivation: hamcrest has **no CVE**. This is hygiene — 1.3 is from 2013 — and it
stops Dependabot from re-proposing a bump that cannot work.

## Verification

- `./mvnw dependency:tree | grep -i hamcrest` → exactly `org.hamcrest:hamcrest:jar:3.0:test`, no
  `hamcrest-core` 1.3 anywhere
- `./mvnw clean verify` on JDK 8 → 210 tests, coverage gate met

Closes #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
