### PR TITLE
ci: keep slf4j-nop in lockstep with velocity's slf4j-api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
       # jfreesvg 4.x needs Java 11 and moves SVGGraphics2D to org.jfree.svg.
       - dependency-name: org.jfree:jfreesvg
         update-types: [version-update:semver-major]
+      # slf4j-nop is here only to silence Velocity, so it has to match the slf4j-api
+      # that velocity-engine-core brings in (1.7.36). slf4j 2.x finds its provider
+      # through ServiceLoader, which the 1.7 api never calls - a 2.x nop would sit on
+      # the classpath and silence nothing, with a green build. Bump it with Velocity.
+      - dependency-name: org.slf4j:slf4j-nop
+        update-types: [version-update:semver-major]
 
   - package-ecosystem: npm
     directory: /website


### PR DESCRIPTION
Follow-up to closing #18 (`slf4j-nop` 1.7.36 → 2.0.18), which passed CI but would have quietly
broken the dependency.

`slf4j-nop` is in this build for one reason: `velocity-engine-core` logs through slf4j, and with no
provider on the classpath every generator prints a binder warning to stderr. Velocity 2.4.1 brings
`slf4j-api` **1.7.36**, and slf4j 2.x providers are found via `ServiceLoader` — which the 1.7 api
never calls. A 2.x nop would sit on the classpath silencing nothing, and the build would stay green
the whole time.

So the version is not independently upgradable: it moves when Velocity's `slf4j-api` moves. This adds
an ignore rule for major bumps with that reasoning in the comment, matching the existing entries for
`junit` and `jfreesvg`.

Verified the file still parses as YAML and that the maven section now ignores exactly
`junit:junit`, `org.jfree:jfreesvg`, `org.slf4j:slf4j-nop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)