### PR TITLE
feat!: replace the hard-coded SNAT list with external_peer on a host

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,3 +35,13 @@ jobs:
           java -cp $JAR com.payneteasy.firewall.MainBind . demo.example.com bind-out
           java -cp $JAR com.payneteasy.firewall.MainKeepalived . fw-1
           java -cp $JAR com.payneteasy.firewall.MainMikrotik . sw-core-1
+
+      # The fat jar is the only delivery form, and releases are cut from tags - this makes the
+      # same jar downloadable from any run, including a pull request's. Last step on purpose:
+      # an artifact exists only when the tests and the demo sweep both passed.
+      - name: Upload the jar
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: firewall-config-jar
+          path: target/firewall-config.jar
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ jar and publishes it as `firewall-config-1.2.0.jar`
 
 ## [Unreleased]
 
+### Added
+
+- **`external_peer: true` on a host.** Declares that the host is outside our address space even
+  though its address is private — a partner reached over a tunnel — so traffic *towards* it is
+  SNAT-ed to the service's `nat:` address, exactly as for a public destination. The flag is read on
+  the destination side only; as a source such a host stays private and produces no DNAT.
+  `examples/demo-network` gained `partner-vpn.example.com` to exercise it.
+
+### Removed
+
+- **The hard-coded SNAT address list in `PacketServiceImpl`.** Fifteen literal addresses (and the
+  `172.16.4.` prefix) marked `// todo hot fix for SNAT` are gone; the same effect is now declared per
+  host with `external_peer: true`.
+
+  **Update your description *before* upgrading the generator.** Every destination that used to match
+  that list needs the flag, including *each* host inside a matched network such as `172.16.4.0/24`. A
+  missed host fails silently: the flow is still generated, just as a plain `FORWARD` with no
+  translation. Generate into a scratch directory with both versions and diff — the difference must be
+  empty.
+
 ## [1.3.0] — 2026-07-29
 
 A safety net and a clear-out. The generated output is now pinned by golden files and a coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,10 @@ Regardless of file:
 - **Netmasks**: only `/24` (implied) and `/16` are supported; anything else throws from
   `TInterface.getLongNetmask()`. The `/24` assumption also leaks into `networks.yml` keys and into the
   "same network" suppression filter.
-- **SNAT for private ranges is a hard-coded address list** in `PacketServiceImpl` (marked
-  `// todo hot fix for SNAT`). Adding a SNAT-ed private network means editing Java, not YAML.
+- **SNAT to a private destination needs `external_peer: true` on that host** (partners behind
+  tunnels). The flag is per host — a whole partner `/24` cannot be declared in one line — and it is
+  read on the destination side only, so such a host as a *source* still produces no DNAT. Forgetting
+  it is silent: the flow comes out as a plain FORWARD with no translation.
 - `findAddress` picks the source address with the longest *binary* prefix match — it is not a routing
   lookup, so multi-homed hosts can get the wrong leg. It is also the one unit-tested method.
 - **No generator creates directories**, and several write CWD-relative fixed paths

--- a/examples/demo-network/README.md
+++ b/examples/demo-network/README.md
@@ -23,7 +23,9 @@ All addresses are from the documentation ranges reserved by RFC 5737
    dmz .2.0   app .20.0   db .22.0   ipmi .6.0        (all 10.20.x.0/24)
        |         |           |        |
    proxy-1    web-1       db-1    sw-core-1
-              adm-1
+      :       adm-1
+      : tunnel
+   partner-vpn.example.com 172.16.4.50
 ```
 
 | Group      | Host                      | Role                                             |
@@ -35,6 +37,7 @@ All addresses are from the documentation ranges reserved by RFC 5737
 | `internal` | `adm-1`                   | Jump host, Prometheus, owner of the shared service definitions |
 | `ipmi`     | `sw-core-1`               | Core switch — the only place cabling is described |
 | `external` | `partner-api.example.com` | Third-party peer on a public address             |
+| `external` | `partner-vpn.example.com` | Third-party peer on a private address, behind a tunnel routed via the DMZ |
 
 ## What it exercises
 
@@ -44,6 +47,7 @@ All addresses are from the documentation ranges reserved by RFC 5737
 | Shared service definitions via `services_links` | declared in `adm-1.yml`, linked everywhere |
 | `access:` by exact host, `group-internal`, `adm-*`, `web-app.service` | `proxy-1.yml`, `db-1.yml` |
 | SNAT (private source → public destination) | `partner-api.example.com.yml` |
+| SNAT to a private peer via `external_peer:` | `partner-vpn.example.com.yml` |
 | DNAT (public source → private destination) | `web-1.yml` |
 | `blockedIpAddresses`, `customRules` | `fw-1.yml` |
 | `mss:` TCPMSS clamping | `partner-api.example.com.yml` |

--- a/examples/demo-network/hosts/external/partner-vpn.example.com.yml
+++ b/examples/demo-network/hosts/external/partner-vpn.example.com.yml
@@ -1,0 +1,23 @@
+description:   Partner settlement API reached over an IPsec tunnel
+justification: Settlement requests to a partner whose own network is RFC 1918
+# The tunnel terminates on the DMZ concentrator, so the partner network is routed through the
+# firewall's DMZ leg rather than through its public one.
+gw: 10.20.2.1
+
+# The address is private, but the host is not part of our address space: `external_peer` is what
+# tells the generator to translate traffic towards it. Without it the flow would be a plain
+# FORWARD, because the SNAT decision otherwise only looks at whether the address is public.
+external_peer: true
+
+interfaces:
+- name: eth0
+  ip:   172.16.4.50
+
+services:
+
+- url:           https
+  name:          partner-settlement
+  description:   Partner settlement API over the tunnel
+  justification: The application submits settlement requests to the partner
+  nat:           https://10.20.2.1
+  access:        [web-1]

--- a/src/main/java/com/payneteasy/firewall/dao/model/THost.java
+++ b/src/main/java/com/payneteasy/firewall/dao/model/THost.java
@@ -30,6 +30,13 @@ public class THost {
 
     public List<TBlockedIpAddress> blockedIpAddresses;
 
+    /**
+     * The host is outside our address space, even though its address is private -
+     * a partner reached over a tunnel. Traffic towards it is SNAT-ed to the nat:
+     * address of the service, exactly as for a public destination.
+     */
+    public boolean external_peer;
+
     public String getDefaultIp() {
         String ip = interfaces.get(0).ip;
         if(Networks.isIpAddress(ip)) {
@@ -74,6 +81,7 @@ public class THost {
                 ", services=" + services +
                 ", color='" + color + '\'' +
                 ", blockedIpAddresses=" + blockedIpAddresses +
+                ", external_peer=" + external_peer +
                 ", services_links='" + services_links + '\'' +
                 ", customRules=" + customRules +
                 '}';

--- a/src/main/java/com/payneteasy/firewall/service/impl/PacketServiceImpl.java
+++ b/src/main/java/com/payneteasy/firewall/service/impl/PacketServiceImpl.java
@@ -94,24 +94,7 @@ public class PacketServiceImpl implements IPacketService {
                     packet.program = service.program;
 
                     // SNAT
-                    if(isPublicAddress(destinationHost.getDefaultIp())
-                            || destinationHost.getDefaultIp().equals("10.12.12.50")
-                            || destinationHost.getDefaultIp().equals("10.170.1.1")
-                            || destinationHost.getDefaultIp().equals("10.53.50.33")
-                            || destinationHost.getDefaultIp().equals("10.2.2.56")
-                            || destinationHost.getDefaultIp().equals("10.2.2.57")
-                            || destinationHost.getDefaultIp().equals("10.102.2.57")
-                            || destinationHost.getDefaultIp().equals("10.102.2.56")
-                            || destinationHost.getDefaultIp().equals("10.102.2.56")
-                            || destinationHost.getDefaultIp().equals("10.58.36.1")
-                            || destinationHost.getDefaultIp().equals("172.16.229.1")
-                            || destinationHost.getDefaultIp().equals("10.201.88.200")
-                            || destinationHost.getDefaultIp().startsWith("172.16.4.")
-                            || destinationHost.getDefaultIp().equals("172.16.3.4")
-                            || destinationHost.getDefaultIp().equals("10.22.198.44")
-                            || destinationHost.getDefaultIp().equals("10.22.198.45")
-                            || destinationHost.getDefaultIp().equals("10.22.198.46")
-                            ) { // todo hot fix for SNAT
+                    if(isPublicAddress(destinationHost.getDefaultIp()) || destinationHost.external_peer) {
 
                         checkNotNull(service.nat, "Direction %s -> %s:%s wants to use NAT address but no NAT address was found."
                                         + "\n\n    Source host     : %s"

--- a/src/test/java/com/payneteasy/firewall/MainWikiTest.java
+++ b/src/test/java/com/payneteasy/firewall/MainWikiTest.java
@@ -39,7 +39,7 @@ public class MainWikiTest {
         generate();
 
         String[] pages = wikiDir.list();
-        assertThat(pages.length, is(20));
+        assertThat(pages.length, is(22));
 
         for (File page : wikiDir.listFiles()) {
             String actual = TestFixtures.readFile(page);
@@ -78,14 +78,14 @@ public class MainWikiTest {
 
     /**
      * MainWiki swallows per-host exceptions into a log warning, so an empty or missing
-     * page is the only symptom of a broken host. Assert both pages exist for all 8 hosts.
+     * page is the only symptom of a broken host. Assert both pages exist for all 9 hosts.
      */
     @Test
     public void generatesTwoNonEmptyPagesForEveryHost() throws Exception {
         generate();
 
         for (String host : new String[]{"adm-1", "db-1", "fw-1", "fw-2", "proxy-1", "web-1",
-                "sw-core-1", "partner-api.example.com"}) {
+                "sw-core-1", "partner-api.example.com", "partner-vpn.example.com"}) {
             for (String suffix : new String[]{"_details", "_packets"}) {
                 File page = new File(wikiDir, host + suffix + ".wiki");
                 assertThat(page.getName() + " exists", page.isFile(), is(true));
@@ -113,7 +113,7 @@ public class MainWikiTest {
 
         // the history reloads without tripping the pageHash == 0 validation
         ConfigDaoYaml reloaded = new ConfigDaoYaml(configDir);
-        assertThat(reloaded.thePagesHistoryMap.size(), is(20));
+        assertThat(reloaded.thePagesHistoryMap.size(), is(22));
         assertThat(reloaded.thePagesHistoryMap.get("services").pageHash, not(0L));
 
         File secondRun = tmp.newFolder("wiki-out-2");
@@ -127,7 +127,7 @@ public class MainWikiTest {
 
         File forced = tmp.newFolder("wiki-out-forced");
         MainWiki.main(new String[]{forced.getPath(), "dummy-key", configDir.getPath(), "--force"});
-        assertThat(forced.list().length, is(20));
+        assertThat(forced.list().length, is(22));
     }
 
     @Test

--- a/src/test/java/com/payneteasy/firewall/dao/ConfigDaoYamlTest.java
+++ b/src/test/java/com/payneteasy/firewall/dao/ConfigDaoYamlTest.java
@@ -43,7 +43,7 @@ public class ConfigDaoYamlTest {
 
     @Test
     public void loadsEveryHostFile() {
-        assertThat(dao.listHosts(), hasSize(8));
+        assertThat(dao.listHosts(), hasSize(9));
     }
 
     /** name and group come from the filesystem, not from the yml body. */
@@ -158,7 +158,7 @@ public class ConfigDaoYamlTest {
     public void findsHostsByGroupAndByGroups() {
         assertThat(dao.findHostsByGroup("internal"), hasSize(6));
         assertThat(dao.findHostsByGroup("nope"), empty());
-        assertThat(dao.findHostsByGroups("external", "ipmi"), hasSize(2));
+        assertThat(dao.findHostsByGroups("external", "ipmi"), hasSize(3));
     }
 
     @Test

--- a/src/test/java/com/payneteasy/firewall/dao/model/ThostYamlRoundTripTest.java
+++ b/src/test/java/com/payneteasy/firewall/dao/model/ThostYamlRoundTripTest.java
@@ -33,6 +33,7 @@ public class ThostYamlRoundTripTest {
         assertThat(loaded.services, hasSize(1));
         assertThat(loaded.services.get(0).program, is("nginx"));
         assertThat(loaded.services.get(0).access, contains("internet", "remote"));
+        assertThat(loaded.external_peer, is(true));
     }
 
     /** dumpAs with Tag.MAP writes plain yaml, without the !!com.payneteasy class tag. */
@@ -77,6 +78,7 @@ public class ThostYamlRoundTripTest {
         host.description = "host description";
         host.justification = "host just";
         host.gw = "10.0.0.1";
+        host.external_peer = true;
         host.interfaces = new ArrayList<>(Arrays.asList(eth0, alias));
         host.services = new ArrayList<>(Arrays.asList(service));
         return host;

--- a/src/test/java/com/payneteasy/firewall/service/impl/PacketServiceImplTest.java
+++ b/src/test/java/com/payneteasy/firewall/service/impl/PacketServiceImplTest.java
@@ -362,12 +362,72 @@ public class PacketServiceImplTest {
     public void forwardPacketsCarrySnatForAPublicDestination() throws Exception {
         boolean found = false;
         for (com.payneteasy.firewall.service.model.Packet packet : service.getForwardPackets("fw-1")) {
-            if ("SNAT".equals(packet.type)) {
+            if ("198.51.100.50".equals(packet.destination_address)) {
+                assertThat(packet.type, is("SNAT"));
                 assertThat(packet.source_nat_address, is("198.51.100.10"));
                 found = true;
             }
         }
         assertThat("an SNAT packet was derived", found, is(true));
+    }
+
+    /**
+     * external_peer: true makes a private destination SNAT-ed too - the partner behind the
+     * tunnel in the demo network. This is the case that used to be a literal address list
+     * in this class.
+     */
+    @Test
+    public void forwardPacketsCarrySnatForAnExternalPeerOnAPrivateAddress() throws Exception {
+        boolean found = false;
+        for (com.payneteasy.firewall.service.model.Packet packet : service.getForwardPackets("fw-1")) {
+            if ("172.16.4.50".equals(packet.destination_address)) {
+                assertThat(packet.type, is("SNAT"));
+                assertThat(packet.source_address, is("10.20.20.21"));
+                assertThat(packet.source_nat_address, is("10.20.2.1"));
+                found = true;
+            }
+        }
+        assertThat("an SNAT packet was derived for the external peer", found, is(true));
+    }
+
+    /** Without the flag the same private destination gets no translation at all. */
+    @Test
+    public void aPrivateDestinationWithoutTheExternalPeerFlagIsNotTranslated() throws Exception {
+        IConfigDao dao = new ConfigDaoYaml(TestFixtures.demoNetworkDir());
+        THost peer = dao.getHostByName("partner-vpn.example.com");
+        peer.external_peer = false;
+        try {
+            boolean found = false;
+            for (com.payneteasy.firewall.service.model.Packet packet
+                    : new PacketServiceImpl(dao).getForwardPackets("fw-1")) {
+                if ("172.16.4.50".equals(packet.destination_address)) {
+                    assertThat(packet.type, is(nullValue()));
+                    found = true;
+                }
+            }
+            assertThat("the flow is still derived, only untranslated", found, is(true));
+        } finally {
+            peer.external_peer = true;
+        }
+    }
+
+    /** An external peer needs nat: for the same reason a public destination does. */
+    @Test
+    public void anExternalPeerWithoutANatAddressFails() throws Exception {
+        IConfigDao dao = new ConfigDaoYaml(TestFixtures.demoNetworkDir());
+        com.payneteasy.firewall.dao.model.TService settlement =
+                dao.getHostByName("partner-vpn.example.com").services.get(0);
+
+        String saved = settlement.nat;
+        settlement.nat = null;
+        try {
+            new PacketServiceImpl(dao).getForwardPackets("fw-1");
+            throw new AssertionError("expected a NullPointerException");
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), containsString("wants to use NAT address but no NAT address was found"));
+        } finally {
+            settlement.nat = saved;
+        }
     }
 
     /**

--- a/src/test/resources/golden/iptables/fw-1
+++ b/src/test/resources/golden/iptables/fw-1
@@ -100,6 +100,10 @@
 -A FORWARD -s 10.20.2.21 -d 198.51.100.50 -i eth0.201 -o eth0.100 -p tcp -m tcp --dport 443 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -s 198.51.100.50 -d 10.20.2.21 -i eth0.100 -o eth0.201 -p tcp -m tcp --sport 443 -m state --state RELATED,ESTABLISHED -j ACCEPT
 
+# web-1 -> https://partner-vpn.example.com   * --> partner-settlement
+-A FORWARD -s 10.20.20.21 -d 172.16.4.50 -i eth0.202 -o eth0.201 -p tcp -m tcp --dport 443 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
+-A FORWARD -s 172.16.4.50 -d 10.20.20.21 -i eth0.201 -o eth0.202 -p tcp -m tcp --sport 443 -m state --state RELATED,ESTABLISHED -j ACCEPT
+
 # adm-1 -> proxy://proxy-1   * --> egress-proxy
 -A FORWARD -s 10.20.20.31 -d 10.20.2.21 -i eth0.202 -o eth0.201 -p tcp -m tcp --dport 3128 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -s 10.20.2.21 -d 10.20.20.31 -i eth0.201 -o eth0.202 -p tcp -m tcp --sport 3128 -m state --state RELATED,ESTABLISHED -j ACCEPT
@@ -168,6 +172,9 @@ COMMIT
 
 # proxy-1 -> https://partner-api.example.com    * --> partner-api
 -A POSTROUTING -s 10.20.2.21  -d 198.51.100.50 -p tcp  --dport 443 -o eth0.100 -j SNAT --to-source 198.51.100.10
+
+# web-1 -> https://partner-vpn.example.com    * --> partner-settlement
+-A POSTROUTING -s 10.20.20.21  -d 172.16.4.50 -p tcp  --dport 443 -o eth0.201 -j SNAT --to-source 10.20.2.1
 
 # partner-api.example.com -> https://web-1     * --> web-app
 -A PREROUTING -d 198.51.100.10 -p tcp -m tcp --dport 443 -j DNAT --to-destination 10.20.20.21:443

--- a/src/test/resources/golden/iptables/fw-2
+++ b/src/test/resources/golden/iptables/fw-2
@@ -97,6 +97,10 @@
 -A FORWARD -s 10.20.2.21 -d 198.51.100.50 -i eth0.201 -o eth0.100 -p tcp -m tcp --dport 443 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -s 198.51.100.50 -d 10.20.2.21 -i eth0.100 -o eth0.201 -p tcp -m tcp --sport 443 -m state --state RELATED,ESTABLISHED -j ACCEPT
 
+# web-1 -> https://partner-vpn.example.com   * --> partner-settlement
+-A FORWARD -s 10.20.20.21 -d 172.16.4.50 -i eth0.202 -o eth0.201 -p tcp -m tcp --dport 443 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
+-A FORWARD -s 172.16.4.50 -d 10.20.20.21 -i eth0.201 -o eth0.202 -p tcp -m tcp --sport 443 -m state --state RELATED,ESTABLISHED -j ACCEPT
+
 # adm-1 -> proxy://proxy-1   * --> egress-proxy
 -A FORWARD -s 10.20.20.31 -d 10.20.2.21 -i eth0.202 -o eth0.201 -p tcp -m tcp --dport 3128 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -s 10.20.2.21 -d 10.20.20.31 -i eth0.201 -o eth0.202 -p tcp -m tcp --sport 3128 -m state --state RELATED,ESTABLISHED -j ACCEPT
@@ -165,6 +169,9 @@ COMMIT
 
 # proxy-1 -> https://partner-api.example.com    * --> partner-api
 -A POSTROUTING -s 10.20.2.21  -d 198.51.100.50 -p tcp  --dport 443 -o eth0.100 -j SNAT --to-source 198.51.100.10
+
+# web-1 -> https://partner-vpn.example.com    * --> partner-settlement
+-A POSTROUTING -s 10.20.20.21  -d 172.16.4.50 -p tcp  --dport 443 -o eth0.201 -j SNAT --to-source 10.20.2.1
 
 # partner-api.example.com -> https://web-1     * --> web-app
 -A PREROUTING -d 198.51.100.10 -p tcp -m tcp --dport 443 -j DNAT --to-destination 10.20.20.21:443

--- a/src/test/resources/golden/iptables/web-1
+++ b/src/test/resources/golden/iptables/web-1
@@ -59,6 +59,10 @@
 -A OUTPUT -p tcp -m tcp -d 10.20.22.21 --dport 5432 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A INPUT  -p tcp -m tcp -s 10.20.22.21 --sport 5432 -m state --state RELATED,ESTABLISHED -j ACCEPT
 
+# https://partner-vpn.example.com   * --> partner-settlement
+-A OUTPUT -p tcp -m tcp -d 172.16.4.50 --dport 443 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
+-A INPUT  -p tcp -m tcp -s 172.16.4.50 --sport 443 -m state --state RELATED,ESTABLISHED -j ACCEPT
+
 # dns://proxy-1   * --> internal-dns
 -A OUTPUT -p udp -m udp -d 10.20.2.21 --dport 53 -m state --state NEW,RELATED,ESTABLISHED -j ACCEPT
 -A INPUT  -p udp -m udp -s 10.20.2.21 --sport 53 -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/src/test/resources/golden/wiki/external_group.wiki
+++ b/src/test/resources/golden/wiki/external_group.wiki
@@ -1,4 +1,5 @@
 h2. external group
 
 |_.Host|_.IP address|_.Description|_.Justification|
+|[[partner-vpn_example_com details|partner-vpn.example.com]]|172.16.4.50|Partner settlement API reached over an IPsec tunnel|Settlement requests to a partner whose own network is RFC 1918|
 |[[partner-api_example_com details|partner-api.example.com]]|198.51.100.50|Partner settlement API|Outgoing settlement requests and incoming callbacks|

--- a/src/test/resources/golden/wiki/fw-1_packets.wiki
+++ b/src/test/resources/golden/wiki/fw-1_packets.wiki
@@ -29,6 +29,7 @@ h2. Forward packets
 |[[adm-1 details|adm-1]]|10.20.20.31|[[db-1 details|db-1]]|10.20.22.21|eth0.202/eth0.203|node-exporter|tcp:9100|||Prometheus node metrics endpoint|Prometheus node metrics endpoint|
 |[[web-1 details|web-1]]|10.20.20.21|[[db-1 details|db-1]]|10.20.22.21|eth0.202/eth0.203|postgres|tcp:5432|||Primary PostgreSQL cluster|Primary PostgreSQL cluster|
 |[[proxy-1 details|proxy-1]]|10.20.2.21|[[partner-api_example_com details|partner-api.example.com]]|198.51.100.50|eth0.201/eth0.100|https|tcp:443|198.51.100.10||Partner settlement API|Partner settlement API|
+|[[web-1 details|web-1]]|10.20.20.21|[[partner-vpn_example_com details|partner-vpn.example.com]]|172.16.4.50|eth0.202/eth0.201|https|tcp:443|10.20.2.1||Partner settlement API over the tunnel|Partner settlement API over the tunnel|
 |[[adm-1 details|adm-1]]|10.20.20.31|[[proxy-1 details|proxy-1]]|10.20.2.21|eth0.202/eth0.201|proxy|tcp:3128|||Forward proxy for outgoing HTTPS callbacks|Forward proxy for outgoing HTTPS callbacks|
 |[[adm-1 details|adm-1]]|10.20.20.31|[[proxy-1 details|proxy-1]]|10.20.2.21|eth0.202/eth0.201|dns|udp:53|||Recursive resolver for the whole estate|Recursive resolver for the whole estate|
 |[[adm-1 details|adm-1]]|10.20.20.31|[[proxy-1 details|proxy-1]]|10.20.2.21|eth0.202/eth0.201|ssh|tcp:22|||Administrative SSH access|Administrative SSH access|

--- a/src/test/resources/golden/wiki/fw-2_packets.wiki
+++ b/src/test/resources/golden/wiki/fw-2_packets.wiki
@@ -29,6 +29,7 @@ h2. Forward packets
 |[[adm-1 details|adm-1]]|10.20.20.31|[[db-1 details|db-1]]|10.20.22.21|eth0.202/eth0.203|node-exporter|tcp:9100|||Prometheus node metrics endpoint|Prometheus node metrics endpoint|
 |[[web-1 details|web-1]]|10.20.20.21|[[db-1 details|db-1]]|10.20.22.21|eth0.202/eth0.203|postgres|tcp:5432|||Primary PostgreSQL cluster|Primary PostgreSQL cluster|
 |[[proxy-1 details|proxy-1]]|10.20.2.21|[[partner-api_example_com details|partner-api.example.com]]|198.51.100.50|eth0.201/eth0.100|https|tcp:443|198.51.100.10||Partner settlement API|Partner settlement API|
+|[[web-1 details|web-1]]|10.20.20.21|[[partner-vpn_example_com details|partner-vpn.example.com]]|172.16.4.50|eth0.202/eth0.201|https|tcp:443|10.20.2.1||Partner settlement API over the tunnel|Partner settlement API over the tunnel|
 |[[adm-1 details|adm-1]]|10.20.20.31|[[proxy-1 details|proxy-1]]|10.20.2.21|eth0.202/eth0.201|proxy|tcp:3128|||Forward proxy for outgoing HTTPS callbacks|Forward proxy for outgoing HTTPS callbacks|
 |[[adm-1 details|adm-1]]|10.20.20.31|[[proxy-1 details|proxy-1]]|10.20.2.21|eth0.202/eth0.201|dns|udp:53|||Recursive resolver for the whole estate|Recursive resolver for the whole estate|
 |[[adm-1 details|adm-1]]|10.20.20.31|[[proxy-1 details|proxy-1]]|10.20.2.21|eth0.202/eth0.201|ssh|tcp:22|||Administrative SSH access|Administrative SSH access|

--- a/src/test/resources/golden/wiki/partner-vpn.example.com_details.wiki
+++ b/src/test/resources/golden/wiki/partner-vpn.example.com_details.wiki
@@ -1,0 +1,8 @@
+h1. partner-vpn.example.com
+
+Partner settlement API reached over an IPsec tunnel
+
+h2. Business goal
+
+Settlement requests to a partner whose own network is RFC 1918
+{{include(partner-vpn_example_com_packets)}}

--- a/src/test/resources/golden/wiki/partner-vpn.example.com_packets.wiki
+++ b/src/test/resources/golden/wiki/partner-vpn.example.com_packets.wiki
@@ -1,0 +1,10 @@
+
+h2. Interfaces
+
+|_.Name|_.IP|_.Virtual IPs|_.DNS|
+|eth0|172.16.4.50|||
+
+h2. Services and input packets
+
+|_.Service name|_.Bound interface|_.Interface address|_.Port|_.Accessed from|_.Description|_.Justification|
+|https:partner-settlement|eth0|172.16.4.50|443|[[web-1 details|web-1]] |Partner settlement API over the tunnel|The application submits settlement requests to the partner|

--- a/src/test/resources/golden/wiki/web-1_packets.wiki
+++ b/src/test/resources/golden/wiki/web-1_packets.wiki
@@ -16,5 +16,6 @@ h2. Output packets
 
 |_.Remote hostname|_.Remote ip address|_.Protocol|_.Port|_.Service name|_.Description|_.Justification|
 |[[db-1 details|db-1]]|10.20.22.21|tcp main-db|5432|postgres|Primary PostgreSQL cluster|The web application stores transaction data here|
+|[[partner-vpn_example_com details|partner-vpn.example.com]]|172.16.4.50|tcp partner-settlement|443|https|Partner settlement API over the tunnel|The application submits settlement requests to the partner|
 |[[proxy-1 details|proxy-1]]|10.20.2.21|udp internal-dns|53|dns|Recursive resolver for the whole estate|Name resolution without exposing internal names outside|
 |[[proxy-1 details|proxy-1]]|10.20.2.21|tcp egress-proxy|3128|proxy|Forward proxy for outgoing HTTPS callbacks|Applications must not reach the internet directly|

--- a/website/src/content/docs/configuration/hosts.md
+++ b/website/src/content/docs/configuration/hosts.md
@@ -47,6 +47,7 @@ services:
 | `color` | `"0xRRGGBB"` | no | Box colour in the L2 diagram and on the printed host label. Defaults to a pale beige. |
 | `blockedIpAddresses` | list | no | See [Blocked addresses](#blocked-addresses). |
 | `customRules` | list | no | See [Custom rules](#custom-rules). |
+| `external_peer` | boolean | no | The host is not part of our address space even though its address is private — a partner reached over a tunnel. Traffic towards it is translated: see [SNAT — a private peer that is not ours](/firewall-config/configuration/services/#snat--a-private-peer-that-is-not-ours). |
 
 `name` and `group` are **not** fields — they come from
 [the file name and directory](/firewall-config/configuration/config-directory/#host-names-and-groups-come-from-the-filesystem).

--- a/website/src/content/docs/configuration/services.md
+++ b/website/src/content/docs/configuration/services.md
@@ -160,6 +160,35 @@ The destination is public, so the firewall between the two translates our source
 -A POSTROUTING -s 10.20.2.21  -d 198.51.100.50 -p tcp  --dport 443 -o eth0.100 -j SNAT --to-source 198.51.100.10
 ```
 
+### SNAT — a private peer that is not ours
+
+A partner reached over a tunnel has an RFC 1918 address, so nothing about it *looks* public — but
+traffic towards it still has to be translated. Mark the peer with `external_peer: true` and it is
+treated exactly like a public destination:
+
+```yaml title="hosts/external/partner-vpn.example.com.yml"
+gw: 10.20.2.1              # the tunnel terminates on the DMZ concentrator
+external_peer: true        # not part of our address space, despite the private address
+
+interfaces:
+- name: eth0
+  ip:   172.16.4.50
+
+services:
+- url:           https
+  name:          partner-settlement
+  justification: The application submits settlement requests to the partner
+  nat:           https://10.20.2.1
+  access:        [web-1]
+```
+
+```sh title="gen/fw-1"
+-A POSTROUTING -s 10.20.20.21  -d 172.16.4.50 -p tcp  --dport 443 -o eth0.201 -j SNAT --to-source 10.20.2.1
+```
+
+The flag is per host, and it only changes the *destination* side of the decision — see
+[Limitations](/firewall-config/internals/limitations/#snat-to-a-private-peer-is-a-per-host-flag).
+
 ### DNAT — a public host reaching a private service
 
 Declared on *our* host, whose service is published at a public address:
@@ -186,8 +215,8 @@ no translation and gets none.
 - A flow whose **source** is public needs `nat:`, or it fails with `No nat for service … at host …`.
 - A flow where **both** ends are public cannot be expressed and raises
   `Trying to config both SNAT and DNAT with …`.
-- "Public" means: not `10.`, not `172.16`, not `192.168`. Some private ranges are hard-coded as
-  needing SNAT anyway — see [Limitations](/firewall-config/internals/limitations/#snat-for-private-ranges-is-hard-coded).
+- "Public" means: not `10.`, not `172.16`, not `192.168` — plus any host marked
+  `external_peer: true`, which counts as public when it is the destination.
 - Give the NAT address a DNS name via `vips.names` and refer to it by name, so re-addressing the
   perimeter is a one-line change.
 

--- a/website/src/content/docs/internals/limitations.md
+++ b/website/src/content/docs/internals/limitations.md
@@ -28,25 +28,27 @@ Both behaviours are pinned by `ModelBeansTest.onlyAnAbsentNetmaskMeansSlash24` /
 `anExplicitSlash24NetmaskThrows`, and the string comparison by `NetworksTest`, so a fix has to
 update those tests deliberately rather than trip over them.
 
-### SNAT for private ranges is hard-coded
+### SNAT to a private peer is a per-host flag
 
-The SNAT decision is `isPublicAddress(destination)` — *plus a literal list of private addresses* baked
-into `PacketServiceImpl`, marked `// todo hot fix for SNAT`:
+The SNAT decision is `isPublicAddress(destination)` **or** `external_peer: true` on the destination
+host:
 
 ```java
-if(isPublicAddress(destinationHost.getDefaultIp())
-        || destinationHost.getDefaultIp().equals("10.12.12.50")
-        || destinationHost.getDefaultIp().equals("10.170.1.1")
-        …
-        || destinationHost.getDefaultIp().startsWith("172.16.4.")
-        ) { // todo hot fix for SNAT
+if (isPublicAddress(destinationHost.getDefaultIp()) || destinationHost.external_peer) {
 ```
 
-These are real addresses from the sites the tool was written for: partner networks reached over
-tunnels, where traffic must be translated even though both ends are RFC 1918. **Adding a
-SNAT-ed private network today requires editing Java and rebuilding the jar** — it cannot be expressed
-in YAML. If you adopt the tool for a different estate, this list is the first thing to make
-configurable.
+`external_peer` exists for partner networks reached over tunnels, where traffic must be translated
+even though both ends are RFC 1918. Those destinations used to be a literal list of real addresses
+inside `PacketServiceImpl`, marked `// todo hot fix for SNAT`, so adding one meant editing Java and
+rebuilding the jar. What is left is the granularity:
+
+- **The flag is per host, not per network.** A whole partner `/24` cannot be declared in one line;
+  every host in it needs its own `external_peer: true`. Forgetting one is silent — the flow is still
+  derived, it just comes out as a plain `FORWARD` with no translation.
+- **It only affects the destination side.** A packet whose *source* is an `external_peer` is not
+  treated as public, so it produces no DNAT. That asymmetry is deliberate: making it symmetric would
+  turn today's untranslated inbound flows into DNAT, and flows that are already SNAT-ed into the
+  `Trying to config both SNAT and DNAT with …` error.
 
 ### `findAddress` is not a routing lookup
 

--- a/website/src/content/docs/internals/packet-derivation.md
+++ b/website/src/content/docs/internals/packet-derivation.md
@@ -93,12 +93,13 @@ handled correctly.
 ## SNAT and DNAT
 
 Direction is never declared. It follows from which side is public, where *public* means: not `10.`,
-not `172.16`, not `192.168`.
+not `172.16`, not `192.168`. A destination host carrying `external_peer: true` counts as public too —
+that is how a partner behind a tunnel gets SNAT despite its RFC 1918 address.
 
 ```mermaid
 graph TD
   start["forward packet<br/>source → destination"]
-  dpub{"destination<br/>public?"}
+  dpub{"destination public<br/>or external_peer?"}
   spub{"source<br/>public?"}
   snat["SNAT<br/>POSTROUTING --to-source nat.address"]
   dnat["DNAT<br/>PREROUTING --to-destination service"]
@@ -119,6 +120,8 @@ graph TD
   the service and the destination host as YAML so you can see what was being resolved.
 - **DNAT** requires `nat:` too — `No nat for service … at host …`.
 - **Both** is not expressible: `Trying to config both SNAT and DNAT with …`.
+- `external_peer` is read on the **destination** only. As a source, such a host is private like any
+  other and produces no DNAT.
 
 The NAT rule is a second projection of the same packet, so a translated flow appears in both `*filter`
 and `*nat`.

--- a/website/src/content/docs/reference/yaml-schema.md
+++ b/website/src/content/docs/reference/yaml-schema.md
@@ -30,6 +30,7 @@ com.payneteasy.firewall.dao.model.THost
 | `color` | `"0xRRGGBB"` | pale beige | no | L2 diagram box and printed host label. |
 | `blockedIpAddresses` | list of [BlockedIpAddress](#blockedipaddress) | — | no | |
 | `customRules` | list of [CustomRule](#customrule) | — | no | |
+| `external_peer` | boolean | `false` | no | The host is outside our address space despite a private address (a partner behind a tunnel). Traffic *towards* it is SNAT-ed to the service's `nat:` address, as for a public destination. |
 
 `name` and `group` are derived from the file name and its parent directory and must not appear in the
 file.


### PR DESCRIPTION
The SNAT decision in `PacketServiceImpl` was `isPublicAddress(destination)` plus a literal list of
fifteen private addresses (and the `172.16.4.` prefix) marked `// todo hot fix for SNAT` — partner
networks reached over tunnels, where traffic must be translated even though both ends are RFC 1918.
Every new partner meant editing Java, rebuilding the jar and cutting a release, and the real
addresses of counterparties sat in the open code and were duplicated in the docs.

They are now declared in the description instead, with `external_peer: true` on the destination host.

## What changed

- `THost.external_peer` (plain public field, snakeyaml-mapped) and a one-line condition in
  `PacketServiceImpl`:
  `if(isPublicAddress(destinationHost.getDefaultIp()) || destinationHost.external_peer)`.
  The comparison is still `getDefaultIp()`, so the granularity is identical to the list it replaces.
- The DNAT branch is deliberately untouched: `external_peer` is read on the destination only.
  Making it symmetric would turn today's untranslated inbound flows into DNAT and already-SNAT-ed
  flows into `Trying to config both SNAT and DNAT with …`.
- `examples/demo-network` gained `partner-vpn.example.com` — a peer on `172.16.4.50`, routed via the
  DMZ leg (`gw: 10.20.2.1`), which is the first private SNAT case the golden files ever covered.
- Docs: `limitations.md` (the trap becomes a documented field, with the two residual limitations),
  `packet-derivation.md`, `services.md` (new NAT example), `yaml-schema.md`, `hosts.md`, and the
  Traps section of `CLAUDE.md`.

## Breaking change — update the description before upgrading

Every destination that used to match the removed list needs `external_peer: true`, including *each*
host inside a matched network such as `172.16.4.0/24`. A missed host fails silently: the flow is
still generated, just as a plain `FORWARD` with no translation. Generate into a scratch directory
with both versions and diff — the difference must be empty. The removal diff in
`PacketServiceImpl` is the checklist.

## Verification

- `./mvnw clean verify` — 213 tests, JaCoCo gate met.
- Golden files regenerated and reviewed: `iptables/fw-1`, `fw-2` (new FORWARD pair plus
  `-A POSTROUTING -s 10.20.20.21 -d 172.16.4.50 … -j SNAT --to-source 10.20.2.1`), `iptables/web-1`,
  and the wiki pages (two new, plus `external_group`, `fw-1/fw-2_packets`, `web-1_packets`).
  Unchanged as expected: bind, keepalived, RouterOS, `l3/network.diag`, `current-l2.svg` — the peer
  is in group `external`, which those generators do not read.
- Full demo-network sweep: every generator accepts the description.
- `cd website && npm run build` — all internal links valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
